### PR TITLE
Teach llama to bootstrap itself

### DIFF
--- a/cmd/internal/cli/config.go
+++ b/cmd/internal/cli/config.go
@@ -36,6 +36,7 @@ func WriteConfig(cfg *Config, configPath string) error {
 	if err != nil {
 		return err
 	}
+	encoded = append(encoded, '\n')
 	os.MkdirAll(path.Dir(configPath), 070)
 	return ioutil.WriteFile(configPath, encoded, 0644)
 }

--- a/cmd/llama/config.go
+++ b/cmd/llama/config.go
@@ -1,0 +1,71 @@
+// Copyright 2020 Nelson Elhage
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/google/subcommands"
+	"github.com/nelhage/llama/cmd/internal/cli"
+)
+
+type ConfigCommand struct {
+	shell bool
+}
+
+func (*ConfigCommand) Name() string     { return "config" }
+func (*ConfigCommand) Synopsis() string { return "Read/Write llama configuration" }
+func (*ConfigCommand) Usage() string {
+	return `config [FLAGS]
+`
+}
+
+func (c *ConfigCommand) SetFlags(flags *flag.FlagSet) {
+	flags.BoolVar(&c.shell, "shell", false, "Write out AWS configuration as a set of shell assignments")
+}
+
+func (c *ConfigCommand) Execute(ctx context.Context, flag *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	if c.shell {
+		return c.shellConfig(ctx)
+	}
+	log.Printf("config: Must specify an action")
+
+	return subcommands.ExitFailure
+}
+
+func shellquote(word string) string {
+	word = strings.ReplaceAll(word, `'`, `'"'"'`)
+	return fmt.Sprintf(`'%s'`, word)
+}
+
+func (c *ConfigCommand) shellConfig(ctx context.Context) subcommands.ExitStatus {
+	global := cli.MustState(ctx)
+
+	if global.Config.Store == "" {
+		log.Printf("llama config: Llama is not fully configured. Try running `llama bootstrap`?")
+		return subcommands.ExitFailure
+	}
+
+	fmt.Fprintf(os.Stdout, "llama_object_store=%s\n", shellquote(global.Config.Store))
+	fmt.Fprintf(os.Stdout, "llama_region=%s\n", shellquote(global.Config.Region))
+	fmt.Fprintf(os.Stdout, "llama_iam_role=%s\n", shellquote(global.Config.IAMRole))
+	fmt.Fprintf(os.Stdout, "llama_ecr_repository=%s\n", shellquote(global.Config.ECRRepository))
+	return subcommands.ExitSuccess
+}

--- a/cmd/llama/internal/bootstrap/bootstrap.go
+++ b/cmd/llama/internal/bootstrap/bootstrap.go
@@ -156,7 +156,10 @@ poll:
 		case "LlamaRole":
 			newCfg.IAMRole = *r.PhysicalResourceId
 		case "LlamaRegistry":
-			newCfg.ECRRepository = *r.PhysicalResourceId
+			newCfg.ECRRepository = fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s",
+				*ident.Account,
+				*session.Config.Region,
+				*r.PhysicalResourceId)
 		}
 	}
 	newCfg.Region = *session.Config.Region

--- a/cmd/llama/internal/bootstrap/bootstrap.go
+++ b/cmd/llama/internal/bootstrap/bootstrap.go
@@ -1,0 +1,121 @@
+// Copyright 2020 Nelson Elhage
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrap
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/google/subcommands"
+	"github.com/nelhage/llama/cmd/internal/cli"
+)
+
+type BootstrapCommand struct {
+	in  *bufio.Reader
+	out io.Writer
+}
+
+func (*BootstrapCommand) Name() string     { return "bootstrap" }
+func (*BootstrapCommand) Synopsis() string { return "Configure Llama and set up AWS resources" }
+func (*BootstrapCommand) Usage() string {
+	return `bootstrap [flags]
+`
+}
+
+func (c *BootstrapCommand) SetFlags(flags *flag.FlagSet) {
+}
+
+func (c *BootstrapCommand) Execute(ctx context.Context, flag *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	if c.in == nil {
+		c.in = bufio.NewReader(os.Stdin)
+	}
+	if c.out == nil {
+		c.out = os.Stdout
+	}
+
+	global := cli.MustState(ctx)
+	session, err := global.Session()
+	if err != nil {
+		log.Printf("Unable to configure AWS session: %s", err.Error())
+		return subcommands.ExitFailure
+	}
+
+	stsSvc := sts.New(session.Copy(aws.NewConfig().WithCredentialsChainVerboseErrors(true)))
+	ident, err := stsSvc.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err != nil {
+		log.Printf("Unable to get AWS account identity information.")
+		log.Printf("Do you have AWS credentials configured?")
+		return subcommands.ExitFailure
+	}
+
+	log.Printf("Configuring llama for AWS account ID %s", *ident.Account)
+
+	if session.Config.Region == nil || *session.Config.Region == "" {
+		region, err := c.readRegion(session)
+		if err != nil {
+			log.Printf("Choosing region: %s", err.Error())
+			return subcommands.ExitFailure
+		}
+		session = session.Copy(aws.NewConfig().WithRegion(region))
+		log.Printf("Will configure llama for region: %s\n", region)
+	} else {
+		log.Printf("Configuring for region: %s [use llama -region REGION bootstrap to override]", *session.Config.Region)
+	}
+
+	return subcommands.ExitSuccess
+}
+
+func (c *BootstrapCommand) readRegion(sess *session.Session) (string, error) {
+	ec2Svc := ec2.New(sess, aws.NewConfig().WithRegion("us-west-2"))
+	regions, err := ec2Svc.DescribeRegions(&ec2.DescribeRegionsInput{})
+	if err != nil {
+		return "", err
+	}
+	for {
+		fmt.Fprintln(c.out, "Which region would you like to use for Llama?")
+		for i, r := range regions.Regions {
+			fmt.Fprintf(c.out, "[%d] %s\n", i, *r.RegionName)
+		}
+		fmt.Fprintf(c.out, "> ")
+		resp, err := c.in.ReadString('\n')
+		if err != nil {
+			return "", err
+		}
+		resp = strings.Trim(resp, " \t\r\n")
+		if resp == "" {
+			continue
+		}
+		n, err := strconv.ParseUint(resp, 10, 64)
+		if err == nil {
+			if int(n) >= len(regions.Regions) {
+				continue
+			}
+			return *regions.Regions[n].RegionName, nil
+		}
+		return resp, nil
+	}
+
+}

--- a/cmd/llama/internal/bootstrap/bootstrap.go
+++ b/cmd/llama/internal/bootstrap/bootstrap.go
@@ -132,7 +132,7 @@ poll:
 			log.Printf("Stack status reason: %s", *stack.StackStatusReason)
 			return subcommands.ExitFailure
 		default:
-			log.Printf("Unknown stack state: %s. Something went wrong.")
+			log.Printf("Unknown stack state: %s. Something went wrong.", *stack.StackStatus)
 			log.Printf("Stack status reason: %s", *stack.StackStatusReason)
 			return subcommands.ExitFailure
 		}

--- a/cmd/llama/internal/bootstrap/bootstrap.go
+++ b/cmd/llama/internal/bootstrap/bootstrap.go
@@ -102,11 +102,11 @@ func (c *BootstrapCommand) Execute(ctx context.Context, flag *flag.FlagSet, _ ..
 		if e, ok := err.(awserr.Error); ok && e.Code() == "AlreadyExistsException" {
 			log.Printf("The `llama` stack already exists.")
 			log.Printf("`llama bootstrap` does not yet support updating the stack.")
-			log.Printf("You'll need to delete it and start from scratch, or update it by hand.")
+			log.Printf("I'm going to proceed assuming it's up-to-date.")
+		} else {
+			log.Printf("Error creating CF stack: %s", err.Error())
 			return subcommands.ExitFailure
 		}
-		log.Printf("Error creating CF stack: %s", err.Error())
-		return subcommands.ExitFailure
 	}
 
 	log.Printf("Stack created. Polling until completion...")

--- a/cmd/llama/internal/bootstrap/template.go
+++ b/cmd/llama/internal/bootstrap/template.go
@@ -28,19 +28,19 @@ const CFTemplate = `{
   "Outputs": {
     "ObjectStore": {
       "Description": "URL to the Llama object store",
-      "Value": {"Fn::Sub": "s3://${LlamaBucket}/obj/"}
+      "Value": {"Fn::Sub": "s3://${Bucket}/obj/"}
     },
     "Repository": {
       "Description": "URL to the Llama Docker repository",
-      "Value": {"Fn::Sub": "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${LlamaRepository}"}
+      "Value": {"Fn::Sub": "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${Repository}"}
     },
     "Role": {
       "Description": "ARN of the Llama IAM role",
-      "Value": {"Fn::GetAtt": ["LlamaRole", "Arn"]}
+      "Value": {"Fn::GetAtt": ["Role", "Arn"]}
     }
   },
   "Resources": {
-    "LlamaBucket": {
+    "Bucket": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
         "LifecycleConfiguration": {
@@ -55,7 +55,7 @@ const CFTemplate = `{
         }
       }
     },
-    "LlamaRole": {
+    "Role": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -92,7 +92,7 @@ const CFTemplate = `{
                   "Resource": [
                     {
                       "Fn::GetAtt": [
-                        "LlamaBucket",
+                        "Bucket",
                         "Arn"
                       ]
                     },
@@ -102,7 +102,7 @@ const CFTemplate = `{
                         [
                           {
                             "Fn::GetAtt": [
-                              "LlamaBucket",
+                              "Bucket",
                               "Arn"
                             ]
                           },
@@ -118,7 +118,7 @@ const CFTemplate = `{
         ]
       }
     },
-    "LlamaRepository": {
+    "Repository": {
       "Type": "AWS::ECR::Repository",
       "Properties": {
         "RepositoryName": {

--- a/cmd/llama/internal/bootstrap/template.go
+++ b/cmd/llama/internal/bootstrap/template.go
@@ -1,0 +1,109 @@
+// Copyright 2020 Nelson Elhage
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrap
+
+const CFTemplate = `{
+  "Parameters": {
+    "ObjectStoreBucket": {
+      "Type": "String",
+      "Description": "A pre-existing S3 bucket to use for llama's object store"
+    },
+    "ObjectStorePrefix": {
+      "Type": "String",
+      "Description": "A prefix in $ObjectStoreBucket under which to store objects",
+      "Default": "/",
+      "AllowedPattern": "/([a-zA-Z0-9_/-]*/)?",
+      "ConstraintDescription": "must be an S3 path prefix starting and ending with /"
+    },
+    "ECRRepositoryName": {
+      "Type": "String",
+      "Description": "The name for the llama ECR repository",
+      "Default": "llama",
+      "AllowedPattern": "(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*",
+      "ConstraintDescription": "must be a valid ECR repository name"
+    }
+  },
+  "Resources": {
+    "LlamaRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              },
+              "Action": "sts:AssumeRole"
+            }
+          ]
+        },
+        "Description": "The role used to invoke llama Lambda functions",
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Policies": [
+          {
+            "PolicyName": "llama-access-object-store",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Sid": "LlamaAccessObjectStore",
+                  "Effect": "Allow",
+                  "Action": [
+                    "s3:PutObject",
+                    "s3:GetObject",
+                    "s3:ListBucketMultipartUploads",
+                    "s3:ListBucket"
+                  ],
+                  "Resource": [
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:s3:::",
+                          {"Ref": "ObjectStoreBucket"}
+                        ]
+                      ]
+                    },
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:s3:::",
+                          {"Ref": "ObjectStoreBucket"},
+                          {"Ref": "ObjectStorePrefix"},
+                          "*"
+                        ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "LlamaRegistry": {
+      "Type": "AWS::ECR::Repository",
+      "Properties": {
+        "RepositoryName": {"Ref": "ECRRepositoryName"}
+      }
+    },
+  }
+}`

--- a/cmd/llama/internal/bootstrap/template.go
+++ b/cmd/llama/internal/bootstrap/template.go
@@ -25,6 +25,20 @@ const CFTemplate = `{
       "ConstraintDescription": "must be a valid ECR repository name"
     }
   },
+  "Outputs": {
+    "ObjectStore": {
+      "Description": "URL to the Llama object store",
+      "Value": {"Fn::Sub": "s3://${LlamaBucket}/obj/"}
+    },
+    "Repository": {
+      "Description": "URL to the Llama Docker repository",
+      "Value": {"Fn::Sub": "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${LlamaRepository}"}
+    },
+    "Role": {
+      "Description": "ARN of the Llama IAM role",
+      "Value": {"Fn::GetAtt": ["LlamaRole", "Arn"]}
+    }
+  },
   "Resources": {
     "LlamaBucket": {
       "Type": "AWS::S3::Bucket",
@@ -104,7 +118,7 @@ const CFTemplate = `{
         ]
       }
     },
-    "LlamaRegistry": {
+    "LlamaRepository": {
       "Type": "AWS::ECR::Repository",
       "Properties": {
         "RepositoryName": {
@@ -113,4 +127,5 @@ const CFTemplate = `{
       }
     }
   }
-}`
+}
+`

--- a/cmd/llama/internal/bootstrap/template.json
+++ b/cmd/llama/internal/bootstrap/template.json
@@ -11,19 +11,19 @@
   "Outputs": {
     "ObjectStore": {
       "Description": "URL to the Llama object store",
-      "Value": {"Fn::Sub": "s3://${LlamaBucket}/obj/"}
+      "Value": {"Fn::Sub": "s3://${Bucket}/obj/"}
     },
     "Repository": {
       "Description": "URL to the Llama Docker repository",
-      "Value": {"Fn::Sub": "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${LlamaRepository}"}
+      "Value": {"Fn::Sub": "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${Repository}"}
     },
     "Role": {
       "Description": "ARN of the Llama IAM role",
-      "Value": {"Fn::GetAtt": ["LlamaRole", "Arn"]}
+      "Value": {"Fn::GetAtt": ["Role", "Arn"]}
     }
   },
   "Resources": {
-    "LlamaBucket": {
+    "Bucket": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
         "LifecycleConfiguration": {
@@ -38,7 +38,7 @@
         }
       }
     },
-    "LlamaRole": {
+    "Role": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -75,7 +75,7 @@
                   "Resource": [
                     {
                       "Fn::GetAtt": [
-                        "LlamaBucket",
+                        "Bucket",
                         "Arn"
                       ]
                     },
@@ -85,7 +85,7 @@
                         [
                           {
                             "Fn::GetAtt": [
-                              "LlamaBucket",
+                              "Bucket",
                               "Arn"
                             ]
                           },
@@ -101,7 +101,7 @@
         ]
       }
     },
-    "LlamaRepository": {
+    "Repository": {
       "Type": "AWS::ECR::Repository",
       "Properties": {
         "RepositoryName": {

--- a/cmd/llama/internal/bootstrap/template.json
+++ b/cmd/llama/internal/bootstrap/template.json
@@ -1,21 +1,4 @@
-// Copyright 2020 Nelson Elhage
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-package bootstrap
-
-// TODO: switch to go:embed once go1.16 is out
-const CFTemplate = `{
+{
   "Parameters": {
     "ECRRepositoryName": {
       "Type": "String",
@@ -113,4 +96,4 @@ const CFTemplate = `{
       }
     }
   }
-}`
+}

--- a/cmd/llama/internal/bootstrap/template.json
+++ b/cmd/llama/internal/bootstrap/template.json
@@ -8,6 +8,20 @@
       "ConstraintDescription": "must be a valid ECR repository name"
     }
   },
+  "Outputs": {
+    "ObjectStore": {
+      "Description": "URL to the Llama object store",
+      "Value": {"Fn::Sub": "s3://${LlamaBucket}/obj/"}
+    },
+    "Repository": {
+      "Description": "URL to the Llama Docker repository",
+      "Value": {"Fn::Sub": "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${LlamaRepository}"}
+    },
+    "Role": {
+      "Description": "ARN of the Llama IAM role",
+      "Value": {"Fn::GetAtt": ["LlamaRole", "Arn"]}
+    }
+  },
   "Resources": {
     "LlamaBucket": {
       "Type": "AWS::S3::Bucket",
@@ -87,7 +101,7 @@
         ]
       }
     },
-    "LlamaRegistry": {
+    "LlamaRepository": {
       "Type": "AWS::ECR::Repository",
       "Properties": {
         "RepositoryName": {

--- a/cmd/llama/main.go
+++ b/cmd/llama/main.go
@@ -31,6 +31,7 @@ func main() {
 	subcommands.Register(subcommands.FlagsCommand(), "")
 
 	subcommands.Register(&bootstrap.BootstrapCommand{}, "config")
+	subcommands.Register(&ConfigCommand{}, "config")
 
 	subcommands.Register(&InvokeCommand{}, "")
 	subcommands.Register(&XargsCommand{}, "")

--- a/cmd/llama/main.go
+++ b/cmd/llama/main.go
@@ -23,10 +23,14 @@ import (
 
 	"github.com/google/subcommands"
 	"github.com/nelhage/llama/cmd/internal/cli"
+	"github.com/nelhage/llama/cmd/llama/internal/bootstrap"
 )
 
 func main() {
 	subcommands.Register(subcommands.HelpCommand(), "")
+	subcommands.Register(subcommands.FlagsCommand(), "")
+
+	subcommands.Register(&bootstrap.BootstrapCommand{}, "config")
 
 	subcommands.Register(&InvokeCommand{}, "")
 	subcommands.Register(&XargsCommand{}, "")
@@ -34,6 +38,8 @@ func main() {
 
 	subcommands.Register(&StoreCommand{}, "internals")
 	subcommands.Register(&GetCommand{}, "internals")
+
+	subcommands.ImportantFlag("region")
 
 	ctx := context.Background()
 	code := runLlama(ctx)
@@ -48,7 +54,7 @@ func runLlama(ctx context.Context) int {
 	debugAWS := false
 	var traceFile string
 	var storeConcurrency int
-	flag.StringVar(&regionOverride, "region", "", "S3 region for commands")
+	flag.StringVar(&regionOverride, "region", "", "AWS region")
 	flag.StringVar(&storeOverride, "store", "", "Path to the llama object store. s3://BUCKET/PATH")
 	flag.BoolVar(&debugAWS, "debug-aws", false, "Log all AWS requests/responses")
 	flag.StringVar(&traceFile, "trace", "", "Log trace to file")

--- a/scripts/_vars
+++ b/scripts/_vars
@@ -1,3 +1,0 @@
-account_id=$(aws --output text --query Account sts get-caller-identity)
-repository_base="${account_id}.dkr.ecr.us-west-2.amazonaws.com"
-repository_url="${account_id}.dkr.ecr.us-west-2.amazonaws.com/llama"

--- a/scripts/build-container
+++ b/scripts/build-container
@@ -2,14 +2,14 @@
 set -eu
 root=$(readlink -f "$(dirname "$0")/..")
 cd "$root"
-. scripts/_vars
+eval "$(llama config -shell)"
 container="$1"
 path="${2-images/$container}"
-repository_tag="$repository_base/llama:$container"
+repository_tag="$llama_ecr_repository:$container"
 
 docker build -t nelhage/llama .
 docker build -t "$repository_tag" "$path"
 if ! docker push "$repository_tag"; then
-    aws ecr get-login-password | docker login --username AWS --password-stdin "$repository_base"
+    aws --region "$llama_region" ecr get-login-password | docker login --username AWS --password-stdin "$(dirname "$llama_ecr_repository")"
     docker push "$repository_tag"
 fi

--- a/scripts/new-function
+++ b/scripts/new-function
@@ -2,19 +2,15 @@
 set -eu
 root=$(readlink -f "$(dirname "$0")/..")
 cd "$root"
-if test -z "${LLAMA_OBJECT_STORE-}"; then
-    echo "You need to set LLAMA_OBJECT_STORE to create a new container." 2>&1
-    exit 1
-fi
-. scripts/_vars
+eval "$(llama config -shell)"
 container="$1"
 path="${2-images/$container}"
 scripts/build-container "$container" "$path"
-aws lambda create-function \
+aws --region "$llama_region" lambda create-function \
     --function-name "$container" --memory-size 1769 \
-    --role "arn:aws:iam::${account_id}:role/llama" \
-    --environment "Variables={LLAMA_OBJECT_STORE=$LLAMA_OBJECT_STORE}" \
+    --role "$llama_iam_role" \
+    --environment "Variables={LLAMA_OBJECT_STORE=$llama_object_store}" \
     --timeout 60 \
     --package-type Image \
-    --code "ImageUri=${repository_url}:$container" >/dev/null
+    --code "ImageUri=${llama_ecr_repository}:$container" >/dev/null
 scripts/wait-for-function "$container"

--- a/scripts/new-function
+++ b/scripts/new-function
@@ -12,5 +12,6 @@ aws --region "$llama_region" lambda create-function \
     --environment "Variables={LLAMA_OBJECT_STORE=$llama_object_store}" \
     --timeout 60 \
     --package-type Image \
+    --tags LlamaFunction=true \
     --code "ImageUri=${llama_ecr_repository}:$container" >/dev/null
 scripts/wait-for-function "$container"

--- a/scripts/update-container
+++ b/scripts/update-container
@@ -4,10 +4,10 @@ root=$(readlink -f "$(dirname "$0")/..")
 cd "$root"
 container="$1"
 path="${2-images/$container}"
-. scripts/_vars
+eval "$(llama config -shell)"
 scripts/build-container "$container" "$path"
-repository_tag="$repository_url:$container"
-aws lambda update-function-code \
+repository_tag="$llama_ecr_repository:$container"
+aws --region "$llama_region" lambda update-function-code \
     --function-name "$container" \
     --image-uri "${repository_tag}" >/dev/null
 scripts/wait-for-function "$container"

--- a/scripts/wait-for-function
+++ b/scripts/wait-for-function
@@ -1,9 +1,11 @@
 #!/bin/bash
 set -eu
+eval "$(llama config -shell)"
 func="$1"
 echo "Sleeping until function is ready..."
 while :; do
-    status=$(aws --query Configuration.LastUpdateStatus --output text lambda get-function --function-name "$func")
+    status=$(aws --region "$llama_region" --query Configuration.LastUpdateStatus --output text \
+                 lambda get-function --function-name "$func")
     case "$status" in
         Successful)
             exit 0


### PR DESCRIPTION
Add a CloudFormation template, and a `llama bootstrap` command to set it up.

Also, add a `llama config -shell` option to dump config as a shell command, so that `scripts/…` can continue to work with the new resources.