### PR TITLE
Add LLAMACC_REMOTE_PREPROCESS mode

### DIFF
--- a/cmd/llamacc/arg_test.go
+++ b/cmd/llamacc/arg_test.go
@@ -43,6 +43,7 @@ func TestParseCompile(t *testing.T) {
 				Flag: Flags{
 					MD: true,
 					C:  true,
+					MF: "platform/linux/linux_ptrace.d",
 				},
 			},
 			false,

--- a/cmd/llamacc/arg_test.go
+++ b/cmd/llamacc/arg_test.go
@@ -116,3 +116,27 @@ func TestParseCompile(t *testing.T) {
 		})
 	}
 }
+
+func TestRewriteWp(t *testing.T) {
+	cases := []struct {
+		in  []string
+		out []string
+	}{
+		{
+			[]string{"-Wall"},
+			[]string{"-Wall"},
+		},
+		{
+			[]string{"-Wp,-MD,foo.d"},
+			[]string{"-MD", "-MF", "foo.d"},
+		},
+		{
+			[]string{"-Wp,-MD,foo.d,-g"},
+			[]string{"-MD", "-MF", "foo.d", "-g"},
+		},
+	}
+	for _, tc := range cases {
+		got := rewriteWp(tc.in)
+		assert.Equal(t, tc.out, got)
+	}
+}

--- a/cmd/llamacc/arg_test.go
+++ b/cmd/llamacc/arg_test.go
@@ -37,6 +37,7 @@ func TestParseCompile(t *testing.T) {
 				PreprocessedLanguage: "cpp-output",
 				Input:                "platform/linux/linux_ptrace.c",
 				Output:               "platform/linux/linux_ptrace.o",
+				UnknownArgs:          []string{"-Wall", "-Werror", "-g"},
 				LocalArgs:            []string{"-MD", "-Wall", "-Werror", "-D_GNU_SOURCE", "-g", "-MF", "platform/linux/linux_ptrace.d"},
 				RemoteArgs:           []string{"-Wall", "-Werror", "-g", "-c"},
 				Flag: Flags{
@@ -87,6 +88,7 @@ func TestParseCompile(t *testing.T) {
 				PreprocessedLanguage: "assembler",
 				Input:                "/home/nelhage/code/boringssl/build/crypto/chacha/chacha-x86_64.S",
 				Output:               "CMakeFiles/crypto.dir/chacha/chacha-x86_64.S.o",
+				UnknownArgs:          []string{"-Wa,--noexecstack", "-Wa,-g"},
 				LocalArgs:            []string{"-DBORINGSSL_DISPATCH_TEST", "-DBORINGSSL_HAVE_LIBUNWIND", "-DBORINGSSL_IMPLEMENTATION", "-I/home/nelhage/code/boringssl/third_party/googletest/include", "-I/home/nelhage/code/boringssl/crypto/../include", "-Wa,--noexecstack", "-Wa,-g"},
 				RemoteArgs:           []string{"-Wa,--noexecstack", "-Wa,-g", "-c"},
 				Flag: Flags{
@@ -101,6 +103,9 @@ func TestParseCompile(t *testing.T) {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			t.Parallel()
 			got, err := ParseCompile(&DefaultConfig, tc.argv)
+			// Don't compare includes or defines for now
+			got.Includes = nil
+			got.Defs = nil
 			if tc.err {
 				require.Error(t, err)
 			} else {

--- a/cmd/llamacc/args.go
+++ b/cmd/llamacc/args.go
@@ -85,9 +85,10 @@ func (c *Compilation) Compiler() string {
 type Flags struct {
 	MD  bool
 	MMD bool
-	C   bool
-	S   bool
 	MF  string
+
+	C bool
+	S bool
 }
 
 func smellsLikeInput(arg string) bool {
@@ -280,7 +281,8 @@ func ParseCompile(cfg *Config, argv []string) (Compilation, error) {
 		out.Output = replaceExt(out.Input, ".o")
 	}
 	if (out.Flag.MD || out.Flag.MMD) && out.Flag.MF == "" {
-		out.LocalArgs = append(out.LocalArgs, "-MF", replaceExt(out.Output, ".d"))
+		out.Flag.MF = replaceExt(out.Output, ".d")
+		out.LocalArgs = append(out.LocalArgs, "-MF", out.Flag.MF)
 	}
 	if out.Language == "" {
 		lang, ok := extLangs[path.Ext(out.Input)]

--- a/cmd/llamacc/config.go
+++ b/cmd/llamacc/config.go
@@ -20,12 +20,13 @@ import (
 )
 
 type Config struct {
-	Verbose        bool
-	Local          bool
-	RemoteAssemble bool
-	FullPreprocess bool
-	Function       string
-	BuildID        string
+	Verbose          bool
+	Local            bool
+	RemoteAssemble   bool
+	FullPreprocess   bool
+	Function         string
+	RemotePreprocess bool
+	BuildID          string
 }
 
 var DefaultConfig = Config{
@@ -55,6 +56,8 @@ func ParseConfig(env []string) Config {
 			out.Function = val
 		case "FULL_PREPROCESS":
 			out.FullPreprocess = val != ""
+		case "REMOTE_PREPROCESS":
+			out.RemotePreprocess = val != ""
 		case "BUILD_ID":
 			out.BuildID = val
 		default:

--- a/cmd/llamacc/dependencies.go
+++ b/cmd/llamacc/dependencies.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"log"
 	"os"
 	"os/exec"
 )
 
-func detectDependencies(cfg *Config, comp *Compilation) ([]string, error) {
+func detectDependencies(ctx context.Context, cfg *Config, comp *Compilation) ([]string, error) {
 	var preprocessor exec.Cmd
 	ccpath, err := exec.LookPath(comp.Compiler())
 	if err != nil {

--- a/cmd/llamacc/dependencies.go
+++ b/cmd/llamacc/dependencies.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"os/exec"
+)
+
+func detectDependencies(cfg *Config, comp *Compilation) ([]string, error) {
+	var preprocessor exec.Cmd
+	ccpath, err := exec.LookPath(comp.Compiler())
+	if err != nil {
+		return nil, err
+	}
+	preprocessor.Path = ccpath
+	preprocessor.Args = []string{comp.Compiler()}
+	preprocessor.Args = append(preprocessor.Args, comp.UnknownArgs...)
+	for _, opt := range comp.Defs {
+		preprocessor.Args = append(preprocessor.Args, opt.Opt)
+		preprocessor.Args = append(preprocessor.Args, opt.Def)
+	}
+	for _, opt := range comp.Includes {
+		preprocessor.Args = append(preprocessor.Args, opt.Opt)
+		preprocessor.Args = append(preprocessor.Args, opt.Path)
+	}
+	preprocessor.Args = append(preprocessor.Args, "-fdirectives-only")
+	preprocessor.Args = append(preprocessor.Args, "-MM", "-MF", "-", comp.Input)
+	var deps bytes.Buffer
+	preprocessor.Stdout = &deps
+	preprocessor.Stderr = os.Stderr
+	if cfg.Verbose {
+		log.Printf("run cpp -MM: %q", preprocessor.Args)
+	}
+	if err := preprocessor.Run(); err != nil {
+		return nil, err
+	}
+	return parseMakeDeps(deps.Bytes())
+}
+
+func parseMakeDeps(buf []byte) ([]string, error) {
+	var deps []string
+	i := 0
+	// Skip the target
+	for i < len(buf) && buf[i] != ':' {
+		i++
+	}
+	i++
+
+	var dep []byte
+	for i < len(buf) {
+		if buf[i] == ' ' || buf[i] == '\n' {
+			if len(dep) > 0 {
+				deps = append(deps, string(dep))
+			}
+			dep = dep[:0]
+			i++
+			continue
+		}
+		if buf[i] == '\\' && i+1 < len(buf) {
+			if buf[i+1] == '\n' {
+				i++
+				continue
+			}
+			if buf[i+1] == ' ' || buf[i+1] == '\\' {
+				dep = append(dep, buf[i+1])
+				i += 2
+				continue
+			}
+		}
+		dep = append(dep, buf[i])
+		i++
+	}
+	if len(dep) > 0 {
+		deps = append(deps, string(dep))
+	}
+
+	return deps, nil
+}

--- a/cmd/llamacc/dependencies.go
+++ b/cmd/llamacc/dependencies.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Nelson Elhage
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/cmd/llamacc/dependencies_test.go
+++ b/cmd/llamacc/dependencies_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseMakeDeps(t *testing.T) {
+	cases := []struct {
+		Src  string
+		Deps []string
+	}{
+		{
+			`foo.o: foo.c`,
+			[]string{"foo.c"},
+		},
+		{
+			`foo.o: `,
+			nil,
+		},
+		{
+			`foo.o: a\ b.c \
+ foo.h`,
+			[]string{"a b.c", "foo.h"},
+		},
+		{
+			`foo.o: a\b.c foo\\bar.h`,
+			[]string{"a\\b.c", "foo\\bar.h"},
+		},
+	}
+	for _, tc := range cases {
+		got, err := parseMakeDeps([]byte(tc.Src))
+		if err != nil {
+			t.Fatalf("parse: %s", err.Error())
+		}
+		assert.Equal(t, tc.Deps, got)
+	}
+}

--- a/cmd/llamacc/dependencies_test.go
+++ b/cmd/llamacc/dependencies_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Nelson Elhage
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/cmd/llamacc/main.go
+++ b/cmd/llamacc/main.go
@@ -124,6 +124,7 @@ func buildRemoteInvoke(ctx context.Context, cfg *Config, comp *Compilation) (*da
 
 	args.Args = []string{comp.Compiler()}
 
+	args.Args = append(args.Args, "-I", toRemote(".", wd))
 	for _, inc := range comp.Includes {
 		args.Args = append(args.Args, inc.Opt, toRemote(inc.Path, wd))
 	}

--- a/cmd/llamacc/main.go
+++ b/cmd/llamacc/main.go
@@ -133,6 +133,9 @@ func main() {
 		err = checkSupported(&cfg, &comp)
 	}
 	if err == nil {
+		_, err = detectDependencies(&cfg, &comp)
+	}
+	if err == nil {
 		err = runLlamaCC(&cfg, &comp)
 		if err != nil {
 			if ex, ok := err.(*exec.ExitError); ok {

--- a/cmd/llamacc/main.go
+++ b/cmd/llamacc/main.go
@@ -35,8 +35,6 @@ import (
 
 func runLlamaCC(cfg *Config, comp *Compilation) error {
 	var err error
-	ccpath, err := exec.LookPath(comp.Compiler())
-	wd, err := os.Getwd()
 	ctx := context.Background()
 	client, err := server.DialWithAutostart(ctx, cli.SocketPath())
 	if err != nil {
@@ -54,6 +52,112 @@ func runLlamaCC(cfg *Config, comp *Compilation) error {
 		span.End()
 		client.TraceSpans(&daemon.TraceSpansArgs{Spans: mt.Close()})
 	}()
+
+	if cfg.RemotePreprocess {
+		return buildRemotePreprocess(ctx, client, cfg, comp)
+	} else {
+		return buildLocalPreprocess(ctx, client, cfg, comp)
+	}
+}
+
+func toRemote(local, wd string) string {
+	var remote string
+	if local[0] == '/' {
+		remote = local[1:]
+	} else {
+		remote = path.Join(wd, local)[1:]
+	}
+	return path.Join("_root", remote)
+}
+
+func remap(local, wd string) files.Mapped {
+	return files.Mapped{
+		Local: files.LocalFile{
+			Path: path.Join(wd, local),
+		},
+		Remote: toRemote(local, wd),
+	}
+}
+
+func buildRemotePreprocess(ctx context.Context, client *daemon.Client, cfg *Config, comp *Compilation) error {
+	args, err := buildRemoteInvoke(ctx, cfg, comp)
+	out, err := client.InvokeWithFiles(args)
+	if err != nil {
+		return err
+	}
+	os.Stdout.Write(out.Stdout)
+	os.Stderr.Write(out.Stderr)
+	if out.InvokeErr != "" {
+		return fmt.Errorf("invoke: %s", out.InvokeErr)
+	}
+	if out.ExitStatus != 0 {
+		return fmt.Errorf("invoke: exit %d", out.ExitStatus)
+	}
+
+	return nil
+}
+
+func buildRemoteInvoke(ctx context.Context, cfg *Config, comp *Compilation) (*daemon.InvokeWithFilesArgs, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	deps, err := detectDependencies(ctx, cfg, comp)
+	if err != nil {
+		return nil, fmt.Errorf("Detecting dependencies: %w", err)
+	}
+
+	args := daemon.InvokeWithFilesArgs{
+		Function: cfg.Function,
+	}
+
+	args.Outputs = args.Outputs.Append(remap(comp.Output, wd))
+
+	if comp.Flag.MF != "" {
+		args.Outputs = args.Outputs.Append(remap(comp.Flag.MF, wd))
+	}
+	args.Files = args.Files.Append(remap(comp.Input, wd))
+	for _, dep := range deps {
+		args.Files = args.Files.Append(remap(dep, wd))
+	}
+
+	args.Args = []string{comp.Compiler()}
+
+	for _, inc := range comp.Includes {
+		args.Args = append(args.Args, inc.Opt, toRemote(inc.Path, wd))
+	}
+	for _, def := range comp.Defs {
+		args.Args = append(args.Args, def.Opt, def.Def)
+	}
+	args.Args = append(args.Args, "-c")
+	args.Args = append(args.Args, "-o", toRemote(comp.Output, wd))
+	args.Args = append(args.Args, toRemote(comp.Input, wd))
+	if comp.Flag.MD {
+		args.Args = append(args.Args, "-MD")
+	}
+	if comp.Flag.MMD {
+		args.Args = append(args.Args, "-MMD")
+	}
+	if comp.Flag.MF != "" {
+		args.Args = append(args.Args, "-MF", toRemote(comp.Flag.MF, wd))
+	}
+	args.Args = append(args.Args, comp.UnknownArgs...)
+	if cfg.Verbose {
+		log.Printf("[llamacc] compiling remotely: %#v", args)
+	}
+	return &args, nil
+}
+
+func buildLocalPreprocess(ctx context.Context, client *daemon.Client, cfg *Config, comp *Compilation) error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	ccpath, err := exec.LookPath(comp.Compiler())
+	if err != nil {
+		return fmt.Errorf("find %s: %w", comp.Compiler(), err)
+	}
 
 	var preprocessed bytes.Buffer
 	{
@@ -77,6 +181,7 @@ func runLlamaCC(cfg *Config, comp *Compilation) error {
 		span.End()
 	}
 
+	prop := tracing.PropagationFromContext(ctx)
 	args := daemon.InvokeWithFilesArgs{
 		Function: cfg.Function,
 		Outputs: []files.Mapped{
@@ -86,7 +191,7 @@ func runLlamaCC(cfg *Config, comp *Compilation) error {
 			},
 		},
 		Stdin: preprocessed.Bytes(),
-		Trace: span.Propagation(),
+		Trace: &prop,
 	}
 	args.Args = []string{comp.Compiler()}
 	args.Args = append(args.Args, comp.RemoteArgs...)
@@ -131,9 +236,6 @@ func main() {
 	}
 	if err == nil {
 		err = checkSupported(&cfg, &comp)
-	}
-	if err == nil {
-		_, err = detectDependencies(&cfg, &comp)
 	}
 	if err == nil {
 		err = runLlamaCC(&cfg, &comp)

--- a/files/list.go
+++ b/files/list.go
@@ -157,7 +157,7 @@ func (f List) TransformToLocal(ctx context.Context, files protocol.FileList) (ok
 func (f List) MakeAbsolute(base string) List {
 	out := make(List, 0, len(f))
 	for _, e := range f {
-		if e.Local.Path != "" {
+		if e.Local.Path != "" && !path.IsAbs(e.Local.Path) {
 			e.Local.Path = path.Join(base, e.Local.Path)
 		}
 		out = append(out, e)

--- a/tracing/context.go
+++ b/tracing/context.go
@@ -47,6 +47,18 @@ func SpanFromContext(ctx context.Context) (*Span, bool) {
 	return v, ok
 }
 
+func PropagationFromContext(ctx context.Context) Propagation {
+	span, ok := SpanFromContext(ctx)
+	if ok {
+		return Propagation{
+			TraceId:  span.TraceId,
+			ParentId: span.ParentId,
+		}
+	} else {
+		return Propagation{}
+	}
+}
+
 func StartSpan(ctx context.Context, name string) (context.Context, *SpanBuilder) {
 	parent, ok := SpanFromContext(ctx)
 	if ok {


### PR DESCRIPTION
This new mode detects dependencies using `gcc -MM`, and then sends individual source files to the cloud. This is more computationally expensive and requires more I/O on the far side, but results in enormous bandwidth savings between the local client and the cloud.