### PR TITLE
Use a semaphore in the daemon to control llamacc concurrency

### DIFF
--- a/cmd/llama/invoke.go
+++ b/cmd/llama/invoke.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/rpc"
 	"os"
 	"text/template"
 
@@ -81,7 +82,7 @@ func (c *InvokeCommand) Execute(ctx context.Context, flag *flag.FlagSet, _ ...in
 		return subcommands.ExitFailure
 	}
 
-	cl, err := server.DialWithAutostart(ctx, cli.SocketPath())
+	cl, err := server.DialWithAutostart(ctx, cli.SocketPath(), rpc.DefaultRPCPath)
 	if err != nil {
 		log.Fatalf("connecting to daemon: %s", err.Error())
 	}

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -19,8 +19,16 @@ import (
 	"net/rpc"
 )
 
-func Dial(_ context.Context, path string) (*Client, error) {
-	conn, err := rpc.DialHTTP("unix", path)
+func Dial(_ context.Context, sockPath string) (*Client, error) {
+	conn, err := rpc.DialHTTP("unix", sockPath)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{conn}, nil
+}
+
+func DialPath(_ context.Context, sockPath string, urlPath string) (*Client, error) {
+	conn, err := rpc.DialHTTPPath("unix", sockPath, urlPath)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/server/methods.go
+++ b/daemon/server/methods.go
@@ -49,6 +49,11 @@ func (d *Daemon) InvokeWithFiles(in *daemon.InvokeWithFilesArgs, out *daemon.Inv
 	defer sb.End()
 	sb.AddField("function", in.Function)
 
+	if in.DropSemaphore {
+		d.releaseSem()
+		defer d.acquireSem(ctx)
+	}
+
 	atomic.AddUint64(&d.stats.Invocations, 1)
 	inflight := atomic.AddUint64(&d.stats.InFlight, 1)
 	sb.AddField("inflight", float64(inflight))

--- a/daemon/server/server_test.go
+++ b/daemon/server/server_test.go
@@ -56,7 +56,7 @@ func TestDialWithAutostart(t *testing.T) {
 			defer func() {
 				ch <- r
 			}()
-			cl, err := server.DialWithAutostart(ctx, sock)
+			cl, err := server.DialWithAutostart(ctx, sock, "/")
 			if err != nil {
 				r.err = err
 				return

--- a/daemon/types.go
+++ b/daemon/types.go
@@ -38,6 +38,10 @@ type InvokeWithFilesArgs struct {
 	Stdin      []byte
 	Files      files.List
 	Outputs    files.List
+
+	// If true, release the llamacc semaphore to allow other
+	// llamacc processes to use CPU while we talk to AWS
+	DropSemaphore bool
 }
 
 type InvokeWithFilesReply struct {


### PR DESCRIPTION
llamacc processes compete for CPU, especially while running `gcc -MM`
to detect dependencies. Use a semaphore on the connection to the
daemon to limit how many may execute concurrently in order to thrash
the CPU less and allow jobs to get into AWS more efficiently. We
implement this by blocking when we open a connection to the server,
and dropping/releasing the semaphore on entry/exit to
`InvokeWithFiles` to allow another worker to make progress.