### PR TITLE
Fix absolute path resolution for Bazel sandboxing.

### DIFF
--- a/cmd/llama/invoke.go
+++ b/cmd/llama/invoke.go
@@ -89,7 +89,7 @@ func (c *InvokeCommand) Execute(ctx context.Context, flag *flag.FlagSet, _ ...in
 	args.Function = flag.Arg(0)
 	args.ReturnLogs = c.logs
 
-	wd, err := os.Getwd()
+	wd, err := files.WorkingDir()
 	if err != nil {
 		log.Fatalf("getcwd: %s", err.Error())
 	}

--- a/cmd/llama/xargs_test.go
+++ b/cmd/llama/xargs_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"testing"
 
+	fs "github.com/nelhage/llama/files"
 	"github.com/nelhage/llama/protocol"
 	"github.com/nelhage/llama/protocol/files"
 	"github.com/nelhage/llama/store"
@@ -96,7 +97,7 @@ func TestPrepareInvocation_Xargs(t *testing.T) {
 	must(t, ioutil.WriteFile(path.Join(tmp, "b.txt"), []byte(contentsB), 0644))
 	must(t, ioutil.WriteFile(path.Join(tmp, "common.txt"), []byte(contentsCommon), 0644))
 
-	oldpwd, _ := os.Getwd()
+	oldpwd, _ := fs.WorkingDir()
 	if err := os.Chdir(tmp); err != nil {
 		t.Fatalf("chdir: %s", err.Error())
 	}

--- a/cmd/llamacc/main.go
+++ b/cmd/llamacc/main.go
@@ -122,7 +122,7 @@ func rewriteMF(ctx context.Context, comp *Compilation) error {
 }
 
 func constructRemotePreprocessInvoke(ctx context.Context, cfg *Config, comp *Compilation) (*daemon.InvokeWithFilesArgs, error) {
-	wd, err := os.Getwd()
+	wd, err := files.WorkingDir()
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +179,7 @@ func constructRemotePreprocessInvoke(ctx context.Context, cfg *Config, comp *Com
 }
 
 func buildLocalPreprocess(ctx context.Context, client *daemon.Client, cfg *Config, comp *Compilation) error {
-	wd, err := os.Getwd()
+	wd, err := files.WorkingDir()
 	if err != nil {
 		return err
 	}

--- a/files/context.go
+++ b/files/context.go
@@ -16,6 +16,7 @@ package files
 
 import (
 	"fmt"
+	"os"
 	"path"
 	"strings"
 )
@@ -74,4 +75,22 @@ func (io *IOContext) InputOutput(file string) (string, error) {
 
 func (io *IOContext) IO(file string) (string, error) {
 	return io.InputOutput(file)
+}
+
+// WorkingDir returns the absolute working directory of the process.
+func WorkingDir() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	// If the working directory is set to the Linux procfs directory
+	// (Bazel sandboxing does this), we need to resolve it to the real
+	// directory so that it can be passed across to the daemon, which
+	// may have a different working directory.
+	if wd == "/proc/self/cwd" {
+		return os.Readlink(wd)
+	}
+
+	return wd, err
 }


### PR DESCRIPTION
The Bazel sandbox sets the working directory to `/proc/self/cwd`.
Passing paths relative to this directory across process boundaries won't
work because the daemon can have a different working directory. The fix is
to consistently use a wrapper that resolves the virtual working directory
symlink and make paths relative to the real underlying directory.