### PR TITLE
Also detect include files found via `-isystem`.

### DIFF
--- a/cmd/llamacc/dependencies.go
+++ b/cmd/llamacc/dependencies.go
@@ -17,12 +17,43 @@ package main
 import (
 	"bytes"
 	"context"
+	"io"
 	"log"
 	"os"
 	"os/exec"
+	"path"
+	"strings"
 
 	"github.com/nelhage/llama/tracing"
 )
+
+func discoverDefaultSearchPath(ctx context.Context, compiler string, cfg *Config, comp *Compilation) ([]string, error) {
+	var exe exec.Cmd
+	exe.Path = compiler
+	exe.Args = []string{comp.LocalCompiler(cfg), "-Wp,-v", "-x", string(comp.Language), "-E", "-"}
+	var stderr bytes.Buffer
+	exe.Stderr = &stderr
+
+	if err := exe.Run(); err != nil {
+		return nil, err
+	}
+
+	var paths []string
+	for {
+		line, err := stderr.ReadString('\n')
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if strings.HasPrefix(line, " /") {
+			dir := strings.Trim(line, " \n")
+			paths = append(paths, path.Clean(dir))
+		}
+	}
+	return paths, nil
+}
 
 func detectDependencies(ctx context.Context, cfg *Config, comp *Compilation) ([]string, error) {
 	_, span := tracing.StartSpan(ctx, "detect_dependencies")
@@ -44,7 +75,7 @@ func detectDependencies(ctx context.Context, cfg *Config, comp *Compilation) ([]
 		preprocessor.Args = append(preprocessor.Args, opt.Opt)
 		preprocessor.Args = append(preprocessor.Args, opt.Path)
 	}
-	preprocessor.Args = append(preprocessor.Args, "-MM", "-MF", "-", comp.Input)
+	preprocessor.Args = append(preprocessor.Args, "-M", "-MF", "-", comp.Input)
 	var deps bytes.Buffer
 	preprocessor.Stdout = &deps
 	preprocessor.Stderr = os.Stderr
@@ -55,9 +86,34 @@ func detectDependencies(ctx context.Context, cfg *Config, comp *Compilation) ([]
 	if err := preprocessor.Run(); err != nil {
 		return nil, err
 	}
+
+	syspaths, err := discoverDefaultSearchPath(ctx, ccpath, cfg, comp)
+
+	if cfg.Verbose {
+		log.Printf("Discovered local system path: %q", syspaths)
+	}
+
 	deplist, err := parseMakeDeps(deps.Bytes())
+
+	deplist = removePaths(deplist, syspaths)
+
 	span.AddField("count", len(deplist))
 	return deplist, err
+}
+
+func removePaths(paths []string, remove []string) []string {
+	out := 0
+outer:
+	for in := 0; in != len(paths); in++ {
+		for _, pfx := range remove {
+			if strings.HasPrefix(paths[in], pfx) {
+				continue outer
+			}
+		}
+		paths[out] = paths[in]
+		out++
+	}
+	return paths[:out]
 }
 
 func parseMakeDeps(buf []byte) ([]string, error) {

--- a/cmd/llamacc/main.go
+++ b/cmd/llamacc/main.go
@@ -83,7 +83,7 @@ func remap(local, wd string) files.Mapped {
 }
 
 func buildRemotePreprocess(ctx context.Context, client *daemon.Client, cfg *Config, comp *Compilation) error {
-	args, err := constructRemotePreprocessInvoke(ctx, cfg, comp)
+	args, err := constructRemotePreprocessInvoke(ctx, client, cfg, comp)
 	if err != nil {
 		return err
 	}
@@ -121,13 +121,13 @@ func rewriteMF(ctx context.Context, comp *Compilation) error {
 	return os.Remove(tmpMF)
 }
 
-func constructRemotePreprocessInvoke(ctx context.Context, cfg *Config, comp *Compilation) (*daemon.InvokeWithFilesArgs, error) {
+func constructRemotePreprocessInvoke(ctx context.Context, client *daemon.Client, cfg *Config, comp *Compilation) (*daemon.InvokeWithFilesArgs, error) {
 	wd, err := files.WorkingDir()
 	if err != nil {
 		return nil, err
 	}
 
-	deps, err := detectDependencies(ctx, cfg, comp)
+	deps, err := detectDependencies(ctx, client, cfg, comp)
 	if err != nil {
 		return nil, fmt.Errorf("Detecting dependencies: %w", err)
 	}

--- a/daemon/client.go
+++ b/daemon/client.go
@@ -53,3 +53,9 @@ func (c *Client) TraceSpans(in *TraceSpansArgs) (*TraceSpansReply, error) {
 	err := c.conn.Call("Daemon.TraceSpans", in, &out)
 	return &out, err
 }
+
+func (c *Client) GetCompilerIncludePath(in *GetCompilerIncludePathArgs) (*GetCompilerIncludePathReply, error) {
+	var out GetCompilerIncludePathReply
+	err := c.conn.Call("Daemon.GetCompilerIncludePath", in, &out)
+	return &out, err
+}

--- a/daemon/types.go
+++ b/daemon/types.go
@@ -86,3 +86,12 @@ type TraceSpansArgs struct {
 }
 
 type TraceSpansReply struct{}
+
+type GetCompilerIncludePathArgs struct {
+	Compiler string
+	Language string
+}
+
+type GetCompilerIncludePathReply struct {
+	Paths []string
+}


### PR DESCRIPTION
To avoid sending the entire world to the server, enumerate the local
compiler's default include path, and exclude those headers.

fixes #23 

This seems to come with a performance cost in my testing, so I'm not sure we want to turn it on by default. I'm hopeful that maybe caching or some other trick can get the cost down to below noise.