### PR TITLE
Support explicit negative values for environment variables.

### DIFF
--- a/cmd/llamacc/config.go
+++ b/cmd/llamacc/config.go
@@ -38,6 +38,16 @@ var DefaultConfig = Config{
 	LocalCXX: "c++",
 }
 
+// BoolConfigTrue returns whether a boolean configuration value is true.
+func BoolConfigTrue(val string) bool {
+	switch val {
+	case "", "0", "N", "n":
+		return false
+	default:
+		return true
+	}
+}
+
 func ParseConfig(env []string) Config {
 	out := DefaultConfig
 	for _, ev := range env {
@@ -52,17 +62,17 @@ func ParseConfig(env []string) Config {
 		val := ev[eq+1:]
 		switch key {
 		case "VERBOSE":
-			out.Verbose = val != ""
+			out.Verbose = BoolConfigTrue(val)
 		case "LOCAL":
-			out.Local = val != ""
+			out.Local = BoolConfigTrue(val)
 		case "REMOTE_ASSEMBLE":
-			out.RemoteAssemble = val != ""
+			out.RemoteAssemble = BoolConfigTrue(val)
 		case "FUNCTION":
 			out.Function = val
 		case "FULL_PREPROCESS":
-			out.FullPreprocess = val != ""
+			out.FullPreprocess = BoolConfigTrue(val)
 		case "LOCAL_PREPROCESS":
-			out.LocalPreprocess = val != ""
+			out.LocalPreprocess = BoolConfigTrue(val)
 		case "BUILD_ID":
 			out.BuildID = val
 		case "LOCAL_CC":

--- a/cmd/llamacc/config_test.go
+++ b/cmd/llamacc/config_test.go
@@ -1,0 +1,31 @@
+// Copyright 2020 Nelson Elhage
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBoolConfigTrue(t *testing.T) {
+	for _, v := range []string{"Y", "y", "9", "1", "foo"} {
+		assert.True(t, BoolConfigTrue(v))
+	}
+
+	for _, v := range []string{"N", "n", "0", ""} {
+		assert.False(t, BoolConfigTrue(v))
+	}
+}


### PR DESCRIPTION
It's easy to forget that setting the LLAMACC environment variables to
any value enables the corresponding setting. Add support for explicitly
setting them to negative values to also disable the corresponding setting.

This bit me a few times when I set LLAMACC_FULL_PREPROCESS=0
and could not figure out what I had done wrong :joy: 