### PR TITLE
Forward preprocessor definitions to the remote compiler.

### DIFF
--- a/cmd/llamacc/arg_test.go
+++ b/cmd/llamacc/arg_test.go
@@ -37,9 +37,8 @@ func TestParseCompile(t *testing.T) {
 				PreprocessedLanguage: "cpp-output",
 				Input:                "platform/linux/linux_ptrace.c",
 				Output:               "platform/linux/linux_ptrace.o",
-				UnknownArgs:          []string{"-Wall", "-Werror", "-g"},
 				LocalArgs:            []string{"-MD", "-Wall", "-Werror", "-D_GNU_SOURCE", "-g", "-MF", "platform/linux/linux_ptrace.d"},
-				RemoteArgs:           []string{"-Wall", "-Werror", "-g", "-c"},
+				RemoteArgs:           []string{"-Wall", "-Werror", "-D_GNU_SOURCE", "-g", "-c"},
 				Flag: Flags{
 					MD: true,
 					C:  true,
@@ -89,9 +88,8 @@ func TestParseCompile(t *testing.T) {
 				PreprocessedLanguage: "assembler",
 				Input:                "/home/nelhage/code/boringssl/build/crypto/chacha/chacha-x86_64.S",
 				Output:               "CMakeFiles/crypto.dir/chacha/chacha-x86_64.S.o",
-				UnknownArgs:          []string{"-Wa,--noexecstack", "-Wa,-g"},
 				LocalArgs:            []string{"-DBORINGSSL_DISPATCH_TEST", "-DBORINGSSL_HAVE_LIBUNWIND", "-DBORINGSSL_IMPLEMENTATION", "-I/home/nelhage/code/boringssl/third_party/googletest/include", "-I/home/nelhage/code/boringssl/crypto/../include", "-Wa,--noexecstack", "-Wa,-g"},
-				RemoteArgs:           []string{"-Wa,--noexecstack", "-Wa,-g", "-c"},
+				RemoteArgs:           []string{"-DBORINGSSL_DISPATCH_TEST", "-DBORINGSSL_HAVE_LIBUNWIND", "-DBORINGSSL_IMPLEMENTATION", "-Wa,--noexecstack", "-Wa,-g", "-c"},
 				Flag: Flags{
 					C: true,
 				},

--- a/cmd/llamacc/dependencies.go
+++ b/cmd/llamacc/dependencies.go
@@ -37,11 +37,7 @@ func detectDependencies(ctx context.Context, client *daemon.Client, cfg *Config,
 	}
 	preprocessor.Path = ccpath
 	preprocessor.Args = []string{comp.LocalCompiler(cfg)}
-	preprocessor.Args = append(preprocessor.Args, comp.UnknownArgs...)
-	for _, opt := range comp.Defs {
-		preprocessor.Args = append(preprocessor.Args, opt.Opt)
-		preprocessor.Args = append(preprocessor.Args, opt.Def)
-	}
+	preprocessor.Args = append(preprocessor.Args, comp.LocalArgs...)
 	for _, opt := range comp.Includes {
 		preprocessor.Args = append(preprocessor.Args, opt.Opt)
 		preprocessor.Args = append(preprocessor.Args, opt.Path)

--- a/cmd/llamacc/main.go
+++ b/cmd/llamacc/main.go
@@ -148,14 +148,13 @@ func constructRemotePreprocessInvoke(ctx context.Context, client *daemon.Client,
 	}
 
 	args.Args = []string{comp.RemoteCompiler(cfg)}
+	args.Args = append(args.Args, comp.RemoteArgs...)
 
 	args.Args = append(args.Args, "-I", toRemote(".", wd))
 	for _, inc := range comp.Includes {
 		args.Args = append(args.Args, inc.Opt, toRemote(inc.Path, wd))
 	}
-	for _, def := range comp.Defs {
-		args.Args = append(args.Args, def.Opt, def.Def)
-	}
+
 	args.Args = append(args.Args, "-c")
 	args.Args = append(args.Args, "-o", toRemote(comp.Output, wd))
 	args.Args = append(args.Args, toRemote(comp.Input, wd))
@@ -171,7 +170,6 @@ func constructRemotePreprocessInvoke(ctx context.Context, client *daemon.Client,
 	if comp.Flag.MF != "" {
 		args.Args = append(args.Args, "-MF", toRemote(comp.Flag.MF+".tmp", wd))
 	}
-	args.Args = append(args.Args, comp.UnknownArgs...)
 	if cfg.Verbose {
 		log.Printf("[llamacc] compiling remotely: %#v", args)
 	}


### PR DESCRIPTION
When doing partial local preprocessing, a remote clang compilation
still needs the preprocessor definitions from the command line so
that the remaining preprocessing can be performed correctly. Partial
preprocessing is necessary to prevent the remote compiler issuing
spurious warnings from macro expansion that would be suppressed in
a local compilation.

This means when spawning a compilation, we should always use either
`LocalArgs` or `RemoteArgs`, and the need to separately preserve
unknown arguments and conditionally restore preprocessor definitions
goes away.

This updates #37.