### PR TITLE
Add warning filtering.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ system. The currently supported options include.
 |`LLAMACC_LOCAL_PREPROCESS`| Run the preprocessor locally and send preprocessed source text to the cloud, instead of individual headers. Uses less total compute but much more bandwidth; this can easily saturate your uplink on large builds. |
 |`LLAMACC_FULL_PREPROCESS`| Run the full preprocessor locally, not just `#include` processing. Disables use of GCC-specific `-fdirectives-only`|
 |`LLAMACC_BUILD_ID`| Assigns an ID to the build. Used for Llama's internal tracing support. |
+|`LLAMACC_FILTER_WARNINGS`| Filters the given comma-separated list of warnings out of all the compilations, e.g.  `LLAMACC_FILTER_WARNINGS=missing-include-dirs,packed-not-aligned`. |
 
 It is strongly recommended that you use absolute paths if you set
 `LLAMACC_LOCAL_CC` and `LLAMACC_LOCAL_CXX`.  Not all build systems will

--- a/cmd/llamacc/args.go
+++ b/cmd/llamacc/args.go
@@ -270,13 +270,31 @@ func ParseCompile(cfg *Config, argv []string) (Compilation, error) {
 
 	args = rewriteWp(args)
 
+	specs := argSpecs
+
+	// Append specs to remove any warning flags that we are filtering.
+	for _, w := range cfg.FilteredWarnings {
+		specs = append(specs,
+			argSpec{
+				flag:   "-W" + w,
+				action: func(*Compilation, string) (filterWhere, error) { return filterBoth, nil },
+				hasArg: false,
+			},
+			argSpec{
+				flag:   "-Wno-" + w,
+				action: func(*Compilation, string) (filterWhere, error) { return filterBoth, nil },
+				hasArg: false,
+			},
+		)
+	}
+
 	i := 0
 	for i < len(args) {
 		arg := args[i]
 		i++
 		if strings.HasPrefix(arg, "-") {
 			found := false
-			for _, spec := range argSpecs {
+			for _, spec := range specs {
 				if !strings.HasPrefix(arg, spec.flag) {
 					continue
 				}

--- a/cmd/llamacc/config.go
+++ b/cmd/llamacc/config.go
@@ -28,6 +28,10 @@ type Config struct {
 	LocalPreprocess bool
 	BuildID         string
 
+	// FilteredWarnings is a list of warnings that we should always filter
+	// out of the compilation
+	FilteredWarnings []string
+
 	LocalCC  string
 	LocalCXX string
 }
@@ -46,6 +50,25 @@ func BoolConfigTrue(val string) bool {
 	default:
 		return true
 	}
+}
+
+// StringArrayConfig splits a string configuration value using ","
+// as the separator and eliding empty elements.
+func StringArrayConfig(val string) []string {
+	if val == "" {
+		return nil
+	}
+
+	var a []string
+
+	for _, s := range strings.Split(val, ",") {
+		s = strings.TrimSpace(s)
+		if len(s) != 0 {
+			a = append(a, s)
+		}
+	}
+
+	return a
 }
 
 func ParseConfig(env []string) Config {
@@ -79,6 +102,8 @@ func ParseConfig(env []string) Config {
 			out.LocalCC = val
 		case "LOCAL_CXX":
 			out.LocalCXX = val
+		case "FILTER_WARNINGS":
+			out.FilteredWarnings = StringArrayConfig(val)
 		default:
 			log.Printf("llamacc: unknown env var: %s", ev)
 		}

--- a/cmd/llamacc/config_test.go
+++ b/cmd/llamacc/config_test.go
@@ -29,3 +29,11 @@ func TestBoolConfigTrue(t *testing.T) {
 		assert.False(t, BoolConfigTrue(v))
 	}
 }
+
+func TestStringArrayConfig(t *testing.T) {
+	assert.Equal(t, []string(nil), StringArrayConfig(""))
+	assert.Equal(t, []string{"b", "a"}, StringArrayConfig("b,a"))
+	assert.Equal(t, []string{"b", "a"}, StringArrayConfig("b,, ,a"))
+	assert.Equal(t, []string{"b", "a"}, StringArrayConfig("b  ,\t a"))
+	assert.Equal(t, []string(nil), StringArrayConfig(",,,,"))
+}


### PR DESCRIPTION
Some build systems build multiple projects and have different ways to
detect the right compilation flags, so it can be difficult to ensure
that the local build sends the right warning flags to the remote compilers.

Add a LLAMACC_FILTER_WARNINGS configuration option that causes llamacc to
filter out the specified warning flags (in both the enabled and disabled
variants). this can be a useful hack when experimenting with llamacc in
a complex build system.

This updates #40.