### PR TITLE
Use a local tempfile for preprocessed output.

### DIFF
--- a/cmd/llamacc/args.go
+++ b/cmd/llamacc/args.go
@@ -89,6 +89,17 @@ func (c *Compilation) RemoteCompiler(cfg *Config) string {
 	return "cc"
 }
 
+// LanguageExt returns the file extension for the current language.
+func (c *Compilation) LanguageExt() string {
+	for k, v := range extLangs {
+		if v == c.Language {
+			return k
+		}
+	}
+
+	panic("unknown language extension")
+}
+
 type Flags struct {
 	MD  bool
 	MMD bool


### PR DESCRIPTION
Preprocessed output tends to be quite large, often multiple megabytes.
Rather than transferring it over the RPC interface, use a tempfile so
that the server doesn't use a lot of memory uneccessarily.

This updates #45.