### PR TITLE
Use streaming compression for files.

### DIFF
--- a/cmd/llama/objects.go
+++ b/cmd/llama/objects.go
@@ -49,7 +49,7 @@ func (c *StoreCommand) Execute(ctx context.Context, flag *flag.FlagSet, _ ...int
 			return subcommands.ExitFailure
 		}
 
-		id, err := global.MustStore().Store(ctx, bytes)
+		id, err := global.MustStore().StoreBytes(ctx, bytes)
 		if err != nil {
 			log.Printf("storing %q: %v\n", arg, err)
 			return subcommands.ExitFailure

--- a/protocol/files/blobs.go
+++ b/protocol/files/blobs.go
@@ -79,7 +79,7 @@ func NewBlob(ctx context.Context, store store.Store, bytes []byte) (*protocol.Bl
 	if base64.StdEncoding.EncodedLen(len(bytes)) < protocol.MaxInlineBlob {
 		return &protocol.Blob{Bytes: bytes}, nil
 	}
-	id, err := store.Store(ctx, bytes)
+	id, err := store.StoreBytes(ctx, bytes)
 	if err != nil {
 		return nil, err
 	}
@@ -100,16 +100,14 @@ func ReadFile(ctx context.Context, store store.Store, path string) (*protocol.Fi
 	if fi.Mode().IsDir() {
 		return nil, errors.New("ReadFile: got directory")
 	}
-	bytes, err := ioutil.ReadAll(fh)
+
+	id, err := store.Store(ctx, fh)
 	if err != nil {
 		return nil, err
 	}
-	blob, err := NewBlob(ctx, store, bytes)
-	if err != nil {
-		return nil, err
-	}
+
 	return &protocol.File{
-		Blob: *blob,
+		Blob: protocol.Blob{Ref: id},
 		Mode: fi.Mode(),
 	}, nil
 }

--- a/store/memory.go
+++ b/store/memory.go
@@ -17,6 +17,8 @@ package store
 import (
 	"context"
 	"encoding/hex"
+	"io"
+	"io/ioutil"
 
 	"github.com/nelhage/llama/protocol"
 	"golang.org/x/crypto/blake2b"
@@ -26,7 +28,16 @@ type inMemory struct {
 	objects map[string][]byte
 }
 
-func (s *inMemory) Store(ctx context.Context, obj []byte) (string, error) {
+func (s *inMemory) Store(ctx context.Context, obj io.Reader) (string, error) {
+	buf, err := ioutil.ReadAll(obj)
+	if err != nil {
+		return "", err
+	}
+
+	return s.StoreBytes(ctx, buf)
+}
+
+func (s *inMemory) StoreBytes(ctx context.Context, obj []byte) (string, error) {
 	sha := blake2b.Sum256(obj)
 	id := hex.EncodeToString(sha[:])
 	s.objects[id] = append([]byte(nil), obj...)

--- a/store/store.go
+++ b/store/store.go
@@ -17,6 +17,7 @@ package store
 import (
 	"context"
 	"errors"
+	"io"
 
 	"github.com/nelhage/llama/protocol"
 )
@@ -30,7 +31,9 @@ type GetRequest struct {
 var ErrNotExists = errors.New("Requested object does not exist")
 
 type Store interface {
-	Store(ctx context.Context, obj []byte) (string, error)
+	StoreBytes(ctx context.Context, obj []byte) (string, error)
+	Store(ctx context.Context, obj io.Reader) (string, error)
+
 	GetObjects(ctx context.Context, gets []GetRequest)
 	FetchAWSUsage(u *protocol.UsageMetrics)
 }


### PR DESCRIPTION
Rather than read large files into memory and process them multiple
times (for hashing and for compression), use streaming compression
for files so that only the compressed output needs to be fully in
memory.

This has the side-effect of the object ID being generated by hashing
the compressed text (which is better because there's less to hash after
compression). This means that the function image needs to be regenerated
to match.

This updates #45.