### PR TITLE
Use -fdebug-prefix-map to clean up debug symbols

### DIFF
--- a/cmd/llamacc/main.go
+++ b/cmd/llamacc/main.go
@@ -149,9 +149,15 @@ func constructRemotePreprocessInvoke(ctx context.Context, client *daemon.Client,
 
 	args.Args = []string{comp.RemoteCompiler(cfg)}
 
-	args.Args = append(args.Args, "-I", toRemote(".", wd))
+	appendInclude := func(opt, local string) {
+		mapped := toRemote(local, wd)
+		args.Args = append(args.Args, opt, mapped)
+		args.Args = append(args.Args, fmt.Sprintf("-fdebug-prefix-map=%s=%s", mapped, local))
+	}
+
+	appendInclude("-I", ".")
 	for _, inc := range comp.Includes {
-		args.Args = append(args.Args, inc.Opt, toRemote(inc.Path, wd))
+		appendInclude(inc.Opt, inc.Path)
 	}
 	for _, def := range comp.Defs {
 		args.Args = append(args.Args, def.Opt, def.Def)


### PR DESCRIPTION
In my testing this mostly works, but GCC still emits a `DW_AT_comp_dir` pointing to the Lambda tempdir. That's annoyingly a bit hard to rewrite since `llamacc` can't know that path ahead of time. We could use a wrapper shell script, but maybe some magic syntax to make the runtime inject the absolute current path would also make sense…

Should mostly fix #54 