### PR TITLE
Correct AWSLambda_FullAccess policy name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ following should suffice:
 * AmazonEC2ContainerRegistryFullAccess
 * AmazonS3FullAccess
 * AWSCloudFormationFullAccess
-* AWSLambdaFullAccess
+* AWSLambda_FullAccess
 * IAMFullAccess
 
 ### Configure llama's AWS resources


### PR DESCRIPTION
Unlike the others, this policy has an underscore in its name.