### PR TITLE
ci: only build/push image for main pushes and same-repo PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,12 @@ jobs:
           ./scripts/dev/check-license
   build-image:
     runs-on: ubuntu-latest
+    # Only build/push images for pushes to main or for PRs originating
+    # from this repo (fork PRs get a read-only token and can't push).
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - uses: actions/checkout@v2
       - name: Login to GitHub Container Registry


### PR DESCRIPTION
## Problem

The `build-image` job ran `docker push` to ghcr.io on every event, including PRs from forks. Fork PRs get a read-only `GITHUB_TOKEN`, so the push failed with:

```
denied: installation not allowed to Write organization package
```

(The image built fine — only the push was denied.)

## Change

Gate the entire `build-image` job so it runs only for:

- pushes to `main` (still tags/pushes `:latest`), or
- pull requests originating from this repo (`head.repo.full_name == github.repository`).

This fixes the fork-PR failure and also stops building an image on every arbitrary branch push. The `ci` job (build/test/lint) is unchanged and still runs on all events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)